### PR TITLE
Fix tool function renaming

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -257,7 +257,13 @@ class Tool:
 
                 return re.sub(pattern, replacement, source_code)
 
-            forward_source_code = forward_source_code.replace(self.name, "forward")
+            # Rename the function definition without affecting references in the body
+            forward_source_code = re.sub(
+                rf"def\s+{re.escape(self.name)}\s*\(",
+                "def forward(",
+                forward_source_code,
+                count=1,
+            )
             forward_source_code = add_self_argument(forward_source_code)
             forward_source_code = forward_source_code.replace("@tool", "").strip()
             tool_code += "\n\n" + textwrap.indent(forward_source_code, "    ")


### PR DESCRIPTION
## Summary
- limit function renaming in `Tool.to_dict` to the definition line to avoid
  altering references elsewhere

## Testing
- `ruff check src/smolagents/tools.py`
- `pytest tests/test_utils.py::test_get_source_standard_function -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68790d0dca3c832fab61a7770d1a3e00