### PR TITLE
Update HF token env var

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -118,7 +118,7 @@ def load_model(
     elif model_type == "InferenceClientModel":
         return InferenceClientModel(
             model_id=model_id,
-            token=api_key or os.getenv("HF_API_KEY"),
+            token=api_key or os.getenv("HF_TOKEN"),
             provider=provider,
         )
     else:


### PR DESCRIPTION
## Summary
- fix `InferenceClientModel` to use the `HF_TOKEN` env variable

## Testing
- `ruff check src/smolagents/cli.py`
- `ruff format src/smolagents/cli.py --check`
- `PYTHONPATH=$(pwd)/src pytest -q` *(fails: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68790fe8a0d0832fb755a3f3f3505ffa