### PR TITLE
Fix Hugging Face term

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -17,7 +17,7 @@ uv pip install .
 flit install
 ```
 
-3. Pass Hugging face key as an environment variable: run `export HF_TOKEN=your_huggingface_api_key_here`
+3. Pass Hugging Face key as an environment variable: run `export HF_TOKEN=your_huggingface_api_key_here`
 You can also set mistral-AI API keys.
 
 4. Compile the file:


### PR DESCRIPTION
## Summary
- correct capitalization for Hugging Face token instructions

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'smolagents')*

------
https://chatgpt.com/codex/tasks/task_e_68790fd77c08832fa85c80bb7ecea0ea