### PR TITLE
Add runtime limit for agents

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -105,6 +105,12 @@ class AgentMaxStepsError(AgentError):
     pass
 
 
+class AgentMaxRuntimeError(AgentError):
+    """Exception raised when the agent reaches its maximum runtime"""
+
+    pass
+
+
 class AgentToolCallError(AgentExecutionError):
     """Exception raised for errors when incorrect arguments are passed to the tool"""
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -68,6 +68,7 @@ from smolagents.utils import (
     AgentError,
     AgentExecutionError,
     AgentGenerationError,
+    AgentMaxRuntimeError,
     AgentToolCallError,
     AgentToolExecutionError,
 )
@@ -482,6 +483,17 @@ class TestAgent:
         assert len(agent.memory.steps) == 5  # Task step + 3 action steps + Final answer
         assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
         assert isinstance(answer, str)
+
+    def test_fails_max_runtime(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),
+            max_steps=50,
+            max_runtime=1,
+        )
+        answer = agent.run("What is 2 multiplied by 3.6452?", max_runtime=1)
+        assert isinstance(answer, str)
+        assert isinstance(agent.memory.steps[-1].error, AgentMaxRuntimeError)
 
     def test_tool_descriptions_get_baked_in_system_prompt(self):
         tool = PythonInterpreterTool()


### PR DESCRIPTION
## Summary
- introduce `max_runtime` attribute to `MultiStepAgent`
- stop agent loop when runtime exceeded
- handle max runtime error with `_handle_max_runtime_reached`
- expose `AgentMaxRuntimeError`
- test new runtime limit
- add execution timeout to the Python executor

The goal is to add a runtime loop to the agent.