### PR TITLE
Implement final answer checks

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -335,6 +335,7 @@ class MultiStepAgent(ABC):
         self.monitor = Monitor(self.model, self.logger)
         self._setup_step_callbacks(step_callbacks)
         self.stream_outputs = False
+        self.interrupt_switch = False
         # Initialize Langfuse trace
         self.trace = langfuse.trace(name=f"Agent_{agent_id}_trace") if langfuse else None
 
@@ -577,9 +578,31 @@ You have been provided with these additional arguments, that you can access usin
             result = self.execute_tool_call(tool_name, arguments)
             self.logger.log(f"Agent {self.agent_id} tool result: {result}", level=LogLevel.INFO)
             if tool_name == "final_answer":
-                self.memory.steps.append(FinalAnswerStep(output=result))
-            # Optionally send result to another agent
-            self.send_message(0, {"tool_call": {"name": "final_answer", "arguments": result}})
+                checks_passed = True
+                for check in self.final_answer_checks:
+                    try:
+                        if not check(result, self.memory):
+                            raise ValueError("failed with error")
+                    except Exception as e:
+                        self.logger.log(
+                            f"Final answer check failed with error: {e}", level=LogLevel.ERROR
+                        )
+                        failed_step = ActionStep(
+                            step_number=self.step_number,
+                            error=AgentError("failed with error", self.logger),
+                            timing=Timing(start_time=time.time(), end_time=time.time()),
+                        )
+                        self._finalize_step(failed_step)
+                        self.memory.steps.append(failed_step)
+                        checks_passed = False
+                        break
+                if checks_passed:
+                    self.memory.steps.append(FinalAnswerStep(output=result))
+                    self.interrupt_switch = True
+                    return result
+            else:
+                # Optionally send result to another agent
+                self.send_message(0, {"tool_call": {"name": "final_answer", "arguments": result}})
         except AgentToolExecutionError as e:
             self.logger.log(f"Tool execution error: {e}", level=LogLevel.ERROR)
 


### PR DESCRIPTION
## Summary
- interrupt switch set at init
- validate `final_answer` results using `final_answer_checks`

## Testing
- `ruff check src/smolagents/agents.py`
- `pytest -k final_answer_checks -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_68797edc0684832f85d52c5147de4c9e